### PR TITLE
Refactor to enable manual lifecycle management

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,20 @@ Add the following to your `project/plugins.sbt` file:
 addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.2")
 ```
 
+Usage
+-----
+
+To use DynamoDB Local in your project you can call `start-dynamodb-local` and `stop-dynamodb-local` directly in `sbt`.
+
 Configuration
 -------------
-The following represents the minimum amount of code required in a `build.sbt` to use sbt-dynamodb.
 
-To use the dynamodb settings in your project have your tests depend on starting the DynamoDB Local instance.
+To have DynamoDB Local automatically start and stop around your tests
 
 ```
+
 test in Test <<= (test in Test).dependsOn(startDynamoDBLocal)
+testOptions in Test += Tests.Cleanup(() => stopDynamoDBLocal.value)
 ```
 
 To download the DynamoDB Local jar to a specific location ("dynamodb-local" is the default)
@@ -54,7 +60,6 @@ The default for the DynamoDB Local instance is to run in "in-memory" mode. To us
 
 ```
 dynamoDBLocalInMemory := false
-
 dynamoDBLocalDBPath := Some("some/directory/here")
 ```
 
@@ -64,12 +69,8 @@ The default for DynamoDB Local instance is to use a separate file for each crede
 dynamoDBLocalSharedDB := true
 ```
 
-The default regarding tests is to both stop & cleanup any data directory if specified. This can be changed using the below settings.
+The default on stop is to cleanup any data directory if specified. This can be changed using
 
 ```
-stopDynamoDBLocalAfterTests := false
-
 cleanDynamoDBLocalAfterStop := false
 ```
-
-##### Note: Regarding stopping the DynamoDB Local instance after the tests. To ensure the instance is stopped, please make sure not to override ```testOptions in Test``` and instead append (e.g. use `+=` instead of `:=`).

--- a/README.md
+++ b/README.md
@@ -19,12 +19,10 @@ Configuration
 -------------
 The following represents the minimum amount of code required in a `build.sbt` to use sbt-dynamodb.
 
-To use the dynamodb settings in your project, add `DynamoDBLocal.settings` to your build and have your tests depend on starting the DynamoDB Local instance.
+To use the dynamodb settings in your project have your tests depend on starting the DynamoDB Local instance.
 
 ```
-DynamoDBLocal.settings
-
-test in Test <<= (test in Test).dependsOn(DynamoDBLocal.Keys.startDynamoDBLocal)
+test in Test <<= (test in Test).dependsOn(startDynamoDBLocal)
 ```
 
 To download the DynamoDB Local jar to a specific location ("dynamodb-local" is the default)

--- a/README.md
+++ b/README.md
@@ -19,14 +19,18 @@ Configuration
 -------------
 The following represents the minimum amount of code required in a `build.sbt` to use sbt-dynamodb.
 
-To use the dynamodb settings in your project, add `DynamoDBLocal.settings` to your build, set the directory to use for the DynamoDB Local jar and have your tests depend on starting the DynamoDB Local instance.
+To use the dynamodb settings in your project, add `DynamoDBLocal.settings` to your build and have your tests depend on starting the DynamoDB Local instance.
 
 ```
 DynamoDBLocal.settings
 
-DynamoDBLocal.Keys.dynamoDBLocalDownloadDirectory := file("dynamodb-local")
-
 test in Test <<= (test in Test).dependsOn(DynamoDBLocal.Keys.startDynamoDBLocal)
+```
+
+To download the DynamoDB Local jar to a specific location ("dynamodb-local" is the default)
+
+```
+dynamoDBLocalDownloadDir := file("my-dir")
 ```
 
 To use a specific version ("latest" is the default DynamoDB version to download and run)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dynamoDBLocalDownloadIfOlderThan := 2.days
 To specify a port other than the default `8000`
 
 ```
-dynamoDBLocalPort := Some(8080)
+dynamoDBLocalPort := 8080
 ```
 
 The default for the DynamoDB Local instance is to run in "in-memory" mode. To use a persistent file based mode you need to set both the data path & turn off in-memory.

--- a/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocal.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocal.scala
@@ -14,6 +14,9 @@ object DynamoDBLocal extends AutoPlugin {
   private val DefaultDynamoDBLocalUrlTemplate = { version: String =>
     s"http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_$version.tar.gz"
   }
+  private val DefaultDynamoDBLocalDownloadFileNameTemplate = { version: String =>
+    s"dynamodb_local_$version.tar.gz"
+  }
   private val DefaultDynamoDBLocalVersion = "latest"
   private val DynamoDBLocalLibDir = "DynamoDBLocal_lib"
   private val DynamoDBLocalJar = "DynamoDBLocal.jar"
@@ -53,7 +56,7 @@ object DynamoDBLocal extends AutoPlugin {
     deployDynamoDBLocal <<= (dynamoDBLocalVersion, dynamoDBLocalDownloadUrl, dynamoDBLocalDownloadDir, dynamoDBLocalDownloadIfOlderThan, streams) map {
       case (ver, url, targetDir, downloadIfOlderThan, streamz) =>
         import sys.process._
-        val outputFile = new File(targetDir, s"dynamodb_local_$ver.tar.gz")
+        val outputFile = new File(targetDir, DefaultDynamoDBLocalDownloadFileNameTemplate(ver))
         if (!targetDir.exists()) {
           streamz.log.info(s"Creating DynamoDB Local directory $targetDir:")
           targetDir.mkdirs()

--- a/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocal.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocal.scala
@@ -68,7 +68,7 @@ object DynamoDBLocal extends AutoPlugin {
           Process(Seq("tar", "xzf", outputFile.getAbsolutePath), targetDir).!
           outputFile
         } else {
-          streamz.log.error(s"Unable to find DyanmoDB Local jar at [${outputFile.getAbsolutePath}]")
+          streamz.log.error(s"Unable to find DynamoDB Local jar at [${outputFile.getAbsolutePath}]")
           sys.exit(1)
         }
     },
@@ -81,9 +81,9 @@ object DynamoDBLocal extends AutoPlugin {
           (if (shared) Seq("-sharedDb") else Nil)
 
         if (!Utils.isDynamoDBLocalRunning(port.getOrElse(DefaultPort))) {
-          streamz.log.info("Starting dyanmodb local:")
+          streamz.log.info("Starting dynamodb local:")
           Process(args).run()
-          streamz.log.info("Waiting for dyanmodb local:")
+          streamz.log.info("Waiting for dynamodb local:")
           Utils.waitForDynamoDBLocal(port.getOrElse(DefaultPort), (s: String) => streamz.log.info(s))
         } else {
           streamz.log.warn(s"dynamodb local is already running on port ${port.getOrElse(DefaultPort)}")
@@ -96,7 +96,7 @@ object DynamoDBLocal extends AutoPlugin {
           sys.exit(1)
         }
     },
-    //if compilation of test classes fails, dyanmodb should not be invoked. (moreover, Test.Cleanup won't execute to stop it...)
+    //if compilation of test classes fails, dynamodb should not be invoked. (moreover, Test.Cleanup won't execute to stop it...)
     startDynamoDBLocal <<= startDynamoDBLocal.dependsOn(compile in Test),
     dynamoDBLocalPid <<= streams map {
       case (streamz) =>
@@ -134,6 +134,6 @@ object DynamoDBLocal extends AutoPlugin {
     Utils.cleanDynamoDBLocal(clean, dataDir, pid)
   }
 
-  private[this] def getDynamoDBLocalPid = Utils.extractDyanmoDBPid("jps".!!)
+  private[this] def getDynamoDBLocalPid = Utils.extractDynamoDBPid("jps".!!)
 
 }

--- a/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocal.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocal.scala
@@ -18,6 +18,7 @@ object DynamoDBLocal extends AutoPlugin {
     s"dynamodb_local_$version.tar.gz"
   }
   private val DefaultDynamoDBLocalVersion = "latest"
+  private val DefaultDynamoDBLocalDownloadDir = file("dynamodb-local")
   private val DynamoDBLocalLibDir = "DynamoDBLocal_lib"
   private val DynamoDBLocalJar = "DynamoDBLocal.jar"
   private val DefaultPort = 8000
@@ -46,6 +47,7 @@ object DynamoDBLocal extends AutoPlugin {
   def settings: Seq[Setting[_]] = Seq(
     dynamoDBLocalVersion := DefaultDynamoDBLocalVersion,
     dynamoDBLocalDownloadUrl := None,
+    dynamoDBLocalDownloadDir := DefaultDynamoDBLocalDownloadDir,
     dynamoDBLocalDownloadIfOlderThan := DefaultDynamoDBLocalDownloadIfOlderThan,
     dynamoDBLocalPort := DefaultPort,
     dynamoDBLocalDBPath := None,

--- a/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocal.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocal.scala
@@ -72,8 +72,7 @@ object DynamoDBLocal extends AutoPlugin {
           Process(Seq("tar", "xzf", outputFile.getAbsolutePath), targetDir).!
           outputFile
         } else {
-          streamz.log.error(s"Unable to find DynamoDB Local jar at [${outputFile.getAbsolutePath}]")
-          sys.exit(1)
+          sys.error(s"Cannot to find DynamoDB Local jar at [${outputFile.getAbsolutePath}].")
         }
     },
     startDynamoDBLocal <<= (deployDynamoDBLocal, dynamoDBLocalDownloadDir, dynamoDBLocalPort, dynamoDBLocalDBPath, dynamoDBLocalInMemory, dynamoDBLocalSharedDB, streams) map {
@@ -97,8 +96,7 @@ object DynamoDBLocal extends AutoPlugin {
           dynamoDBLocalPid := pid
           pid
         }.getOrElse {
-          streamz.log.error(s"Cannot find dynamodb local PID")
-          sys.exit(1)
+          sys.error(s"Cannot find dynamodb local PID")
         }
     },
     //if compilation of test classes fails, dynamodb should not be invoked. (moreover, Test.Cleanup won't execute to stop it...)

--- a/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocal.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocal.scala
@@ -21,19 +21,20 @@ object DynamoDBLocal extends AutoPlugin {
   private val DefaultDynamoDBLocalDownloadIfOlderThan = 2.days
 
   object Keys {
-    val dynamoDBLocalVersion = settingKey[String]("DynamoDB Local version to download.")
+    val dynamoDBLocalVersion = settingKey[String]("DynamoDB Local version to download. Defaults to latest.")
     val dynamoDBLocalDownloadUrl = settingKey[Option[String]]("DynamoDB Local URL to download jar from (optional).")
-    val dynamoDBLocalDownloadDirectory = settingKey[File]("The directory DynamoDB Local jar will be downloaded to.")
-    val dynamoDBLocalDownloadIfOlderThan = settingKey[Duration]("Re-download the jar if the existing one is older than this.")
-    val dynamoDBLocalPort = settingKey[Option[Int]]("The port number that DynamoDB Local will use to communicate with your application. If you do not specify this option, the default port is 8000.")
-    val dynamoDBLocalDBPath = settingKey[Option[String]]("The directory where DynamoDB Local will write its database file. If you do not specify this option, the file will be written to the current directory.")
+    val dynamoDBLocalDownloadDir = settingKey[File]("The directory the DynamoDB Local jar will be downloaded to. Defaults to dynamodb-local.")
+    val dynamoDBLocalDownloadIfOlderThan = settingKey[Duration]("Re-download the jar if the existing one is older than this. Defaults to 2 days.")
+    val dynamoDBLocalPort = settingKey[Option[Int]]("The port number that DynamoDB Local will use to communicate with your application. Defaults to 8000.")
+    val dynamoDBLocalDBPath = settingKey[Option[String]]("The directory where DynamoDB Local will write its database file. Defaults to the current directory.")
     val dynamoDBLocalInMemory = settingKey[Boolean]("Instead of using a database file, DynamoDB Local will run in memory. When you stop DynamoDB Local, none of the data will be saved.")
-    val dynamoDBLocalSharedDB = settingKey[Boolean]("DynamoDB Local creates a single database file named shared-local-instance.db. Every program that connects to DynamoDB Local will access this file. If you delete the file, you will lose any data you have stored in it")
-    val deployDynamoDBLocal = TaskKey[File]("deploy-dynamodb-local")
-    val startDynamoDBLocal = TaskKey[String]("start-dynamodb-local")
-    val dynamoDBLocalPid = TaskKey[String]("dynamodb-local-pid")
+    val dynamoDBLocalSharedDB = settingKey[Boolean]("DynamoDB Local will use a single, shared database file. All clients will interact with the same set of tables regardless of their region and credential configuration.")
     val stopDynamoDBLocalAfterTests = SettingKey[Boolean]("stop-dynamodb-local-after-tests")
     val cleanDynamoDBLocalAfterStop = SettingKey[Boolean]("clean-dynamodb-local-after-tests")
+
+    val dynamoDBLocalPid = TaskKey[String]("dynamodb-local-pid")
+    val deployDynamoDBLocal = TaskKey[File]("deploy-dynamodb-local")
+    val startDynamoDBLocal = TaskKey[String]("start-dynamodb-local")
     val stopDynamoDBLocal = TaskKey[Unit]("stop-dynamodb-local")
   }
 
@@ -49,7 +50,7 @@ object DynamoDBLocal extends AutoPlugin {
     dynamoDBLocalSharedDB := false,
     stopDynamoDBLocalAfterTests := true,
     cleanDynamoDBLocalAfterStop := true,
-    deployDynamoDBLocal <<= (dynamoDBLocalVersion, dynamoDBLocalDownloadUrl, dynamoDBLocalDownloadDirectory, dynamoDBLocalDownloadIfOlderThan, streams) map {
+    deployDynamoDBLocal <<= (dynamoDBLocalVersion, dynamoDBLocalDownloadUrl, dynamoDBLocalDownloadDir, dynamoDBLocalDownloadIfOlderThan, streams) map {
       case (ver, url, targetDir, downloadIfOlderThan, streamz) =>
         import sys.process._
         val outputFile = new File(targetDir, s"dynamodb_local_$ver.tar.gz")
@@ -71,7 +72,7 @@ object DynamoDBLocal extends AutoPlugin {
           sys.exit(1)
         }
     },
-    startDynamoDBLocal <<= (deployDynamoDBLocal, dynamoDBLocalDownloadDirectory, dynamoDBLocalPort, dynamoDBLocalDBPath, dynamoDBLocalInMemory, dynamoDBLocalSharedDB, streams) map {
+    startDynamoDBLocal <<= (deployDynamoDBLocal, dynamoDBLocalDownloadDir, dynamoDBLocalPort, dynamoDBLocalDBPath, dynamoDBLocalInMemory, dynamoDBLocalSharedDB, streams) map {
       case (dyanmoHome, baseDir, port, dbPath, inMem, shared, streamz) =>
         val args = Seq("java", s"-Djava.library.path=${new File(baseDir, DynamoDBLocalLibDir).getAbsolutePath}", "-jar", new File(baseDir, DynamoDBLocalJar).getAbsolutePath) ++
           port.map(p => Seq("-port", p.toString)).getOrElse(Nil) ++

--- a/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocal.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocal.scala
@@ -23,7 +23,11 @@ object DynamoDBLocal extends AutoPlugin {
   private val DefaultPort = 8000
   private val DefaultDynamoDBLocalDownloadIfOlderThan = 2.days
 
-  object Keys {
+  // auto enable plugin http://www.scala-sbt.org/0.13/docs/Plugins.html#Root+plugins+and+triggered+plugins
+  override def trigger = allRequirements
+
+  // inject project keys http://www.scala-sbt.org/0.13/docs/Plugins.html#Controlling+the+import+with+autoImport
+  object autoImport {
     val dynamoDBLocalVersion = settingKey[String]("DynamoDB Local version to download. Defaults to latest.")
     val dynamoDBLocalDownloadUrl = settingKey[Option[String]]("DynamoDB Local URL to download jar from (optional).")
     val dynamoDBLocalDownloadDir = settingKey[File]("The directory the DynamoDB Local jar will be downloaded to. Defaults to dynamodb-local.")
@@ -41,9 +45,10 @@ object DynamoDBLocal extends AutoPlugin {
     val stopDynamoDBLocal = TaskKey[Unit]("stop-dynamodb-local")
   }
 
-  import Keys._
+  import autoImport._
 
-  def settings: Seq[Setting[_]] = Seq(
+  // inject project settings http://www.scala-sbt.org/0.13/docs/Plugins.html#projectSettings+and+buildSettings
+  override lazy val projectSettings = Seq(
     dynamoDBLocalVersion := DefaultDynamoDBLocalVersion,
     dynamoDBLocalDownloadUrl := None,
     dynamoDBLocalDownloadDir := DefaultDynamoDBLocalDownloadDir,

--- a/src/main/scala/com/localytics/sbt/dynamodb/Utils.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/Utils.scala
@@ -8,7 +8,7 @@ private[dynamodb] object Utils {
 
   private val ProcessIDRegex = """\d+ DynamoDBLocal\.jar""".r
 
-  def extractDyanmoDBPid(input: String): Option[String] = ProcessIDRegex.findFirstIn(input).map(_.split(" ")(0))
+  def extractDynamoDBPid(input: String): Option[String] = ProcessIDRegex.findFirstIn(input).map(_.split(" ")(0))
 
   def cleanDynamoDBLocal(clean: Boolean, dataDir: Option[String], pid: String) = {
     if (clean && dataDir.exists(d => new File(d).exists())) sbt.IO.delete(new File(dataDir.get))
@@ -30,7 +30,7 @@ private[dynamodb] object Utils {
         socket.close()
       }.recover {
         case e: Exception =>
-          infoPrintFunc(s"Waiting for dyanmodb local to boot on port $port")
+          infoPrintFunc(s"Waiting for dynamodb local to boot on port $port")
           Thread.sleep(500)
           continue = false
       }

--- a/src/main/scala/com/localytics/sbt/dynamodb/Utils.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/Utils.scala
@@ -1,7 +1,5 @@
 package com.localytics.sbt.dynamodb
 
-import java.io.File
-
 import scala.util.Try
 
 private[dynamodb] object Utils {
@@ -9,10 +7,6 @@ private[dynamodb] object Utils {
   private val ProcessIDRegex = """\d+ DynamoDBLocal\.jar""".r
 
   def extractDynamoDBPid(input: String): Option[String] = ProcessIDRegex.findFirstIn(input).map(_.split(" ")(0))
-
-  def cleanDynamoDBLocal(clean: Boolean, dataDir: Option[String], pid: String) = {
-    if (clean && dataDir.exists(d => new File(d).exists())) sbt.IO.delete(new File(dataDir.get))
-  }
 
   def isDynamoDBLocalRunning(port: Int): Boolean = {
     Try {
@@ -34,6 +28,18 @@ private[dynamodb] object Utils {
           Thread.sleep(500)
           continue = false
       }
+    }
+  }
+
+  def killPidCommand(pid: String): String = {
+    val osName = System.getProperty("os.name") match {
+      case n: String if !n.isEmpty => n
+      case _ => System.getProperty("os")
+    }
+    if (osName.toLowerCase.contains("windows")) {
+      s"Taskkill /PID $pid /F"
+    } else {
+      s"kill $pid"
     }
   }
 

--- a/src/test/scala/com/localytics/sbt/dynamodb/UtilsTest.scala
+++ b/src/test/scala/com/localytics/sbt/dynamodb/UtilsTest.scala
@@ -16,7 +16,7 @@ class UtilsTest extends FunSpec with Matchers {
           |51449
         """.stripMargin
 
-      Utils.extractDyanmoDBPid(jpsOutput) should equal(Some("59022"))
+      Utils.extractDynamoDBPid(jpsOutput) should equal(Some("59022"))
     }
 
   }


### PR DESCRIPTION
We want to support running dynamodb in multiple test configurations (namely fun / it tests). This PR makes wiring a bit more manual but also more flexible.