### PR TITLE
Fix DynamoDB Local download URL

### DIFF
--- a/src/main/scala/com/localytics/sbt/dynamodb/DeployDynamoDBLocal.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/DeployDynamoDBLocal.scala
@@ -29,7 +29,7 @@ object DeployDynamoDBLocal {
       targetDir.mkdirs()
     }
     if (!targz.exists() || isStale(targz) || !validGzip(targz)) {
-      val remoteFile = url.getOrElse(s"https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz")
+      val remoteFile = url.getOrElse(s"https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_$ver.tar.gz")
       streamz.log.info(s"Downloading targz from [$remoteFile] to [${targz.getAbsolutePath}]")
       (new URL(remoteFile) #> targz).!!
     }

--- a/src/main/scala/com/localytics/sbt/dynamodb/DeployDynamoDBLocal.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/DeployDynamoDBLocal.scala
@@ -29,7 +29,7 @@ object DeployDynamoDBLocal {
       targetDir.mkdirs()
     }
     if (!targz.exists() || isStale(targz) || !validGzip(targz)) {
-      val remoteFile = url.getOrElse(s"http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_$ver.tar.gz")
+      val remoteFile = url.getOrElse(s"https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz")
       streamz.log.info(s"Downloading targz from [$remoteFile] to [${targz.getAbsolutePath}]")
       (new URL(remoteFile) #> targz).!!
     }


### PR DESCRIPTION
The current URL points to 404 and breaks our builds! Please note that according to the official DynamoDB Local documentation: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html#DynamoDBLocal.DownloadingAndRunning the official URL is different.

Thanks for releasing a new version.
Thanks for the plugin.