### PR TITLE
Force tar to use local file. Escape jar path in regex when capturing PID.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.5.5] - 2017-03-08
+- Fix Windows bugs caused by Windows paths
+
 ## [1.5.4] - 2017-02-27
 - Enable different settings for different configurations
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation
 Add the following to your `project/plugins.sbt` file:
 
 ```
-addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.4")
+addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.5")
 ```
 
 sbt 0.13.6+ is supported, 0.13.5 should work with the right bintray resolvers

--- a/src/main/scala/com/localytics/sbt/dynamodb/DeployDynamoDBLocal.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/DeployDynamoDBLocal.scala
@@ -36,7 +36,7 @@ object DeployDynamoDBLocal {
     if (!validGzip(targz)) sys.error(s"Invalid gzip file at [${targz.getAbsolutePath}]")
     if (!jar.exists() || !validJar(jar)) {
       streamz.log.info(s"Extracting jar from [${targz.getAbsolutePath}] to [${jar.getAbsolutePath}]")
-      Process(Seq("tar", "--force-local", "-xzf", targz.getAbsolutePath), targetDir).!!
+      Process(Seq("tar", "xzf", targz.getName), targetDir).!!
     }
     if (!validJar(jar)) sys.error(s"Invalid jar file at [${jar.getAbsolutePath}]")
     jar

--- a/src/main/scala/com/localytics/sbt/dynamodb/DeployDynamoDBLocal.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/DeployDynamoDBLocal.scala
@@ -36,7 +36,7 @@ object DeployDynamoDBLocal {
     if (!validGzip(targz)) sys.error(s"Invalid gzip file at [${targz.getAbsolutePath}]")
     if (!jar.exists() || !validJar(jar)) {
       streamz.log.info(s"Extracting jar from [${targz.getAbsolutePath}] to [${jar.getAbsolutePath}]")
-      Process(Seq("tar", "xzf", targz.getAbsolutePath), targetDir).!!
+      Process(Seq("tar", "--force-local", "-xzf", targz.getAbsolutePath), targetDir).!!
     }
     if (!validJar(jar)) sys.error(s"Invalid jar file at [${jar.getAbsolutePath}]")
     jar

--- a/src/main/scala/com/localytics/sbt/dynamodb/PidUtils.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/PidUtils.scala
@@ -1,11 +1,12 @@
 package com.localytics.sbt.dynamodb
 
 import java.io.File
+import java.util.regex.Pattern
 
 object PidUtils {
 
   def extractPid(input: String, port: Int, jar: File): Option[String] = {
-    val pidPortRegex = s"\\d+ ${jar.getAbsolutePath} -port $port".r
+    val pidPortRegex = s"\\d+ ${Pattern.quote(jar.getAbsolutePath)} -port $port".r
     pidPortRegex.findFirstIn(input).map(_.split(" ")(0))
   }
 

--- a/src/test/scala/com/localytics/sbt/dynamodb/PidUtilsTest.scala
+++ b/src/test/scala/com/localytics/sbt/dynamodb/PidUtilsTest.scala
@@ -8,32 +8,36 @@ import org.scalatest.Matchers
 class PidUtilsTest extends FunSpec with Matchers {
 
   describe("PidUtils") {
+    val jarPath = if (PidUtils.osName.toLowerCase.contains("windows"))
+      "C:\\Users\\person\\code\\repository\\aws-mocks\\.dynamo-db\\DynamoDBLocal.jar"
+    else
+      "/Users/person/code/repository/aws-mocks/.dynamo-db/DynamoDBLocal.jar"
 
     it("should extract PID correctly") {
       val jpsOutput =
-        """
-          |92433 sun.tools.jps.Jps -ml
-          |88818 /usr/local/Cellar/sbt/0.13.7/libexec/sbt-launch.jar
-          |88421 /usr/local/Cellar/sbt/0.13.7/libexec/sbt-launch.jar
-          |5895 com.intellij.database.remote.RemoteJdbcServer com.mysql.jdbc.Driver
-          |92431 /Users/person/code/repository/aws-mocks/dynamo-db/DynamoDBLocal.jar -port 8000 -inMemory -sharedDb
-          |74414 /usr/local/Cellar/sbt/0.13.7/libexec/sbt-launch.jar
+        s"""
+           |92433 sun.tools.jps.Jps -ml
+           |88818 /usr/local/Cellar/sbt/0.13.7/libexec/sbt-launch.jar
+           |88421 /usr/local/Cellar/sbt/0.13.7/libexec/sbt-launch.jar
+           |5895 com.intellij.database.remote.RemoteJdbcServer com.mysql.jdbc.Driver
+           |92431 $jarPath -port 8000 -inMemory -sharedDb
+           |74414 /usr/local/Cellar/sbt/0.13.7/libexec/sbt-launch.jar
         """.stripMargin
-      val jar = new File("/Users/person/code/repository/aws-mocks/dynamo-db/DynamoDBLocal.jar")
+      val jar = new File(jarPath)
       PidUtils.extractPid(jpsOutput, 8000, jar) should equal(Some("92431"))
     }
 
     it("should resolve multiple local dynamodb instances") {
       val jpsOutput =
-        """
-          |92433 sun.tools.jps.Jps -ml
-          |92430 /Users/person/code/macro/repository/aws-mocks/dynamo-db/DynamoDBLocal.jar -port 8001 -inMemory -sharedDb
-          |92433 /Users/person/code/mono/repository/aws-mocks/dynamo-db/DynamoDBLocal.jar -port 8002 -inMemory -sharedDb
-          |5895 com.intellij.database.remote.RemoteJdbcServer com.mysql.jdbc.Driver
-          |92431 /Users/person/code/repository/aws-mocks/dynamo-db/DynamoDBLocal.jar -port 8000 -inMemory -sharedDb
-          |74414 /usr/local/Cellar/sbt/0.13.7/libexec/sbt-launch.jar
+        s"""
+           |92433 sun.tools.jps.Jps -ml
+           |92430 $jarPath -port 8001 -inMemory -sharedDb
+           |92433 $jarPath -port 8002 -inMemory -sharedDb
+           |5895 com.intellij.database.remote.RemoteJdbcServer com.mysql.jdbc.Driver
+           |92431 $jarPath -port 8000 -inMemory -sharedDb
+           |74414 /usr/local/Cellar/sbt/0.13.7/libexec/sbt-launch.jar
         """.stripMargin
-      val jar = new File("/Users/person/code/repository/aws-mocks/dynamo-db/DynamoDBLocal.jar")
+      val jar = new File(jarPath)
       PidUtils.extractPid(jpsOutput, 8000, jar) should equal(Some("92431"))
 
     }


### PR DESCRIPTION
**Testing done**
- Tests pass on Windows
- Using a locally published version on Windows correctly downloads and unzips the jar, captures the PID, and kills it after tests.

Fixes https://github.com/localytics/sbt-dynamodb/issues/19