### PR TITLE
Update DynamoDB-Local docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 sbt-dynamodb
 ===============
 
-Support for running [DynamoDB Local](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.html) in tests.
+Support for running [DynamoDB Local](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) in tests.
 
 [![MIT license](https://img.shields.io/badge/license-MIT%20License-blue.svg)](LICENSE)
 


### PR DESCRIPTION
The Tools link is dead and leads to a confusing page. This PR updates it with the correct location.