### PR TITLE
Add sbt 1.0 Support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,11 @@ scalacOptions ++= Seq(
 )
 
 // This is an auto plugin
-// http://www.scala-sbt.org/0.13/docs/Plugins.html#Creating+an+auto+plugin
+// http://www.scala-sbt.org/1.x/docs/Plugins.html#Creating+an+auto+plugin
 sbtPlugin := true
 
 // Generate a POM
-// http://www.scala-sbt.org/0.13/docs/Publishing.html#Modifying+the+generated+POM
+// http://www.scala-sbt.org/1.x/docs/Publishing.html#Modifying+the+generated+POM
 publishMavenStyle := false
 
 // MIT License for bintray
@@ -39,11 +39,11 @@ bintrayOrganization := Some("localytics")
 bintrayPackageLabels := Seq("localytics", "sbt", "aws", "dynamodb", "test", "testing")
 
 // Error on conflicting dependencies
-// http://www.scala-sbt.org/0.13/docs/Library-Management.html#Conflict+Management
+// http://www.scala-sbt.org/1.x/docs/Library-Management.html#Conflict+Management
 conflictManager := ConflictManager.strict
 
 // Error on circular dependencies
-// http://www.scala-sbt.org/0.13/docs/sbt-0.13-Tech-Previews.html#Circular+dependency
+// http://www.scala-sbt.org/1.x/docs/sbt-0.13-Tech-Previews.html#Circular+dependency
 updateOptions := updateOptions.value.withCircularDependencyLevel(CircularDependencyLevel.Error)
 
 libraryDependencies +=

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ description := "Support for running DynamoDB Local in your integration tests"
 
 organization := "com.localytics"
 
+scalaVersion := "2.12.3"
+
 // Sane set of compiler flags
 scalacOptions ++= Seq(
   "-deprecation",         // Emit warning and location for usages of deprecated APIs
@@ -44,4 +46,9 @@ conflictManager := ConflictManager.strict
 // http://www.scala-sbt.org/0.13/docs/sbt-0.13-Tech-Previews.html#Circular+dependency
 updateOptions := updateOptions.value.withCircularDependencyLevel(CircularDependencyLevel.Error)
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+libraryDependencies +=
+  ( "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+    // Scalatest 3.0.1 is slightly behind sbt and Scala dependencies for these two modules, so they must be excluded
+    // while Strict dependency checking is enabled.
+    exclude("org.scala-lang.modules", s"scala-xml_${scalaBinaryVersion.value}")
+    exclude("org.scala-lang.modules", s"scala-parser-combinators_${scalaBinaryVersion.value}") )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.13
+sbt.version=1.0.0
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")

--- a/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocalKeys.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/DynamoDBLocalKeys.scala
@@ -56,12 +56,20 @@ object DynamoDBLocalKeys {
       dynamoDBLocalPort.value,
       dynamoDBLocalDownloadDir.value,
       streams.value),
-    dynamoDBLocalTestCleanup := Tests.Cleanup(() =>
-      StopDynamoDBLocal(dynamoDBLocalDBPath.value,
-        dynamoDBLocalCleanAfterStop.value,
-        dynamoDBLocalPort.value,
-        dynamoDBLocalDownloadDir.value,
-        streams.value)),
+    dynamoDBLocalTestCleanup := {
+      val dynamoDBLocalDBPathValue = dynamoDBLocalDBPath.value
+      val dynamoDBLocalCleanAfterStopValue = dynamoDBLocalCleanAfterStop.value
+      val dynamoDBLocalPortValue = dynamoDBLocalPort.value
+      val dynamoDBLocalDownloadDirValue = dynamoDBLocalDownloadDir.value
+      val streamsValue = streams.value
+      Tests.Cleanup(() =>
+        StopDynamoDBLocal(
+          dynamoDBLocalDBPathValue,
+          dynamoDBLocalCleanAfterStopValue,
+          dynamoDBLocalPortValue,
+          dynamoDBLocalDownloadDirValue,
+          streamsValue))
+    },
     startDynamoDBLocal := startDynamoDBLocal
       .dependsOn(deployDynamoDBLocal)
       .value

--- a/src/main/scala/com/localytics/sbt/dynamodb/StartDynamoDBLocal.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/StartDynamoDBLocal.scala
@@ -4,8 +4,8 @@ import java.net.Socket
 
 import sbt.File
 import sbt.Keys._
-import sbt._
 
+import scala.sys.process._
 import scala.util.Try
 
 object StartDynamoDBLocal {

--- a/src/main/scala/com/localytics/sbt/dynamodb/StopDynamoDBLocal.scala
+++ b/src/main/scala/com/localytics/sbt/dynamodb/StopDynamoDBLocal.scala
@@ -2,7 +2,8 @@ package com.localytics.sbt.dynamodb
 
 import sbt.File
 import sbt.Keys._
-import sbt._
+
+import scala.sys.process._
 
 object StopDynamoDBLocal {
 


### PR DESCRIPTION
This PR upgrades sbt-dynamodb to use sbt 1.0.

I have tested the resulting plugin in my own projects that use sbt-dynamodb for test runs.